### PR TITLE
Solve Concurrent Request Issue

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,6 +2,8 @@
 
 Simple API for generating shortening API, inspired by [tinly.url](https://tinyurl.com/) and [bit.ly](https://bitly.com/). the main goals for this project were learning system design and golang implementation.
 
+visit [project wiki](https://github.com/peterchu999/url-shorterner/wiki) to learn more
+
 ## Run The App
 
 ```sh

--- a/controllers/shorterner.go
+++ b/controllers/shorterner.go
@@ -14,7 +14,7 @@ func CreateShort(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	shortUrl, errCreate := services.CreateShortUrl(createShortUrlDto)
+	shortUrl, errCreate := services.URLServiceObject.CreateShortUrl(createShortUrlDto)
 	if errCreate != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": errCreate.Error()})
 		return

--- a/services/shorterner.go
+++ b/services/shorterner.go
@@ -5,9 +5,18 @@ import (
 	"peterchu999/url-shorterner/model"
 	repo "peterchu999/url-shorterner/repository"
 	urlUtils "peterchu999/url-shorterner/utils/urls"
+	"sync"
 )
 
-func CreateShortUrl(createShortUrlDto CreateShortUrlDto) (string, error) {
+type URLService struct {
+	sync.Mutex
+}
+
+var URLServiceObject *URLService
+
+func (us *URLService) CreateShortUrl(createShortUrlDto CreateShortUrlDto) (string, error) {
+	us.Lock()
+	defer us.Unlock()
 	idx, err := repo.GetCurrentCount()
 	if err != nil {
 		return "", err
@@ -17,5 +26,10 @@ func CreateShortUrl(createShortUrlDto CreateShortUrlDto) (string, error) {
 		LongUrl:  createShortUrlDto.LongUrl,
 		ShortUrl: shortUrl,
 	})
+
 	return shortUrl, err
+}
+
+func init() {
+	URLServiceObject = &URLService{}
 }


### PR DESCRIPTION
Previously if 2 concurrent request were coming to create a short url, the second request would return as error because both request generated the same shortUrl. that issue were solve using mutex at service level, so that 2 concurrent incoming request need to wait when the service are being used.

Ideally the mutex lock would be bind to the document (database / Mongo). However, there are several database operation need to be locked at time (read the count, insert a new url based on the count), so at current level locking the mutex on service level were more easier to implement and understand